### PR TITLE
Update zstandard.zig to use new API

### DIFF
--- a/fuzzers/zstandard.zig
+++ b/fuzzers/zstandard.zig
@@ -20,20 +20,18 @@ pub fn main() !void {
     const data = try stdin.readToEndAlloc(allocator, std.math.maxInt(usize));
     defer allocator.free(data);
 
-    // The current zstandard decompression implementation cannot handle anything that doesn't start with the 'magic number'
-    // so just reject any input that doesn't
-    // Note: would probably be better to just prepend the magic number but oh well
-    if (data.len < 4) return;
-    const frame_type = std.compress.zstandard.decompress.frameType(data) catch return;
-    // There is no decode API that can handle anything besides the zstandard magic number, so
-    // only continue if that's true
-    if (frame_type != .zstandard) return;
-
     const verify_checksum = false;
     // TODO: Vary this? What is a good size to use?
     const window_size_max = 256 * 1024 * 1024; // 256 MiB
-    const decoded = std.compress.zstandard.decompress.decodeZStandardFrameAlloc(allocator, data, verify_checksum, window_size_max) catch return {
-        return;
-    };
-    defer allocator.free(decoded);
+    const result = std.compress.zstandard.decompress.decodeFrameAlloc(
+        allocator,
+        data,
+        verify_checksum,
+        window_size_max,
+    ) catch return;
+    
+    switch (result) {
+        .zstandard => |decoded| allocator.free(decoded.bytes),
+        .skippable => {},
+    }
 }


### PR DESCRIPTION
There is a new `decodeFrameAlloc()` entry point that (hopefully) can be fed any random bytes without crashing, and basically provides the same checks previously done manually.