### PR TITLE
zstandard-verify: Update for zstandardStream change

### DIFF
--- a/tools/zstandard-verify.zig
+++ b/tools/zstandard-verify.zig
@@ -29,7 +29,7 @@ pub fn main() !void {
     // zstandardStream
     {
         var in_stream = std.io.fixedBufferStream(input);
-        var stream = try std.compress.zstandard.zstandardStream(allocator, in_stream.reader());
+        var stream = std.compress.zstandard.zstandardStream(allocator, in_stream.reader(), 1 << 23);
         defer stream.deinit();
         const result = try stream.reader().readAllAlloc(allocator, std.math.maxInt(usize));
         defer allocator.free(result);


### PR DESCRIPTION
zstandardStream() got an extra parameter - the maximum window size to support and no longer returns an error union.