### PR TITLE
update tar fuzzer to the new tar api

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Current fuzzers:
 - `zstandard-compare` which compares the results of the `zstd` reference implementation to Zig's `std.compress.zstd.decompress.decode` implementation
 - `zstandard-compare-alloc` which compares the results of the `zstd` reference implementation to Zig's `std.compress.zstd.decompress.decodeAlloc` implementation
 - `zstandard-compare-stream` which compares the results of the `zstd` reference implementation to Zig's `std.compress.zstd.decompressStream` implementation
-- `tar` which calls `std.tar.pipeToFileSystem` (requires the code from https://github.com/ziglang/zig/pull/15382)
+- `tar` which uses `std.tar.iterator` to simulate an untar operation (but does not write to the filesystem)
+- `tar-fs` which calls `std.tar.pipeToFileSystem` (and actually writes to the filesystem)
 
 Requires [AFL++](https://github.com/AFLplusplus/AFLplusplus) with `afl-clang-lto` to be installed.
 
@@ -95,6 +96,10 @@ valgrind ./zig-out/bin/fuzz-tokenizer-debug < 'outputs/tokenizer/default/crashes
 ### `std.compress.zstandard`
 
 - https://github.com/ziglang/zig/pull/14394 (a whole bunch of stuff during the PR process)
+
+### `std.tar`
+
+- https://github.com/ziglang/zig/pull/19038
 
 ### In upstream/third-party projects
 

--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *std.Build) !void {
     _ = try addFuzzer(b, "xz", &.{});
     _ = try addFuzzer(b, "zstandard", &.{});
     _ = try addFuzzer(b, "tar", &.{});
+    _ = try addFuzzer(b, "tar-fs", &.{});
 
     const deflate_puff = try addFuzzer(b, "deflate-puff", &.{});
     for (deflate_puff.libExes()) |lib_exe| {

--- a/fuzzers/tar-fs.zig
+++ b/fuzzers/tar-fs.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+
+export fn cMain() void {
+    main() catch unreachable;
+}
+
+comptime {
+    @export(cMain, .{ .name = "main", .linkage = .Strong });
+}
+
+var tmp_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+var tmp_dirpath: ?[]const u8 = null;
+
+pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
+    if (tmp_dirpath) |tmp_path| {
+        std.fs.cwd().deleteTree(tmp_path) catch |err| {
+            std.debug.print("failed to deleteTree during panic: {}\n", .{err});
+        };
+    }
+    std.builtin.default_panic(msg, error_return_trace, ret_addr);
+}
+
+pub fn main() !void {
+    // Setup an allocator that will detect leaks/use-after-free/etc
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    // this will check for leaks and crash the program if it finds any
+    defer std.debug.assert(gpa.deinit() == .ok);
+    const allocator = gpa.allocator();
+
+    // Read the data from stdin
+    const stdin = std.io.getStdIn();
+    const data = try stdin.readToEndAlloc(allocator, std.math.maxInt(usize));
+    defer allocator.free(data);
+    var fbs = std.io.fixedBufferStream(data);
+    const reader = fbs.reader();
+
+    // Run tar parser and write untar data to the file system
+    const rand_int = std.crypto.random.int(u64);
+    tmp_dirpath = std.fmt.bufPrint(&tmp_buf, "/tmp/zig-tar-fuzzing/{x}", .{rand_int}) catch unreachable;
+
+    const tmpdir = try std.fs.cwd().makeOpenPath(tmp_dirpath.?, .{});
+    defer std.fs.cwd().deleteTree(tmp_dirpath.?) catch |err| {
+        std.debug.print("failed to deleteTree during defer: {}\n", .{err});
+        @panic("failed to deleteTree in defer");
+    };
+    std.tar.pipeToFileSystem(tmpdir, reader, .{ .mode_mode = .ignore }) catch {};
+}

--- a/fuzzers/tar.zig
+++ b/fuzzers/tar.zig
@@ -8,21 +8,6 @@ comptime {
     @export(cMain, .{ .name = "main", .linkage = .Strong });
 }
 
-var tmp_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-var tmp_dirpath: ?[]const u8 = null;
-
-pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
-    if (tmp_dirpath) |tmp_path| {
-        std.fs.cwd().deleteTree(tmp_path) catch |err| {
-            std.debug.print("failed to deleteTree during panic: {}\n", .{err});
-        };
-    }
-    std.builtin.default_panic(msg, error_return_trace, ret_addr);
-}
-
-// Test just parser, without writing to the file system. Faster.
-const no_fs = false;
-
 pub fn main() !void {
     // Setup an allocator that will detect leaks/use-after-free/etc
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -37,32 +22,19 @@ pub fn main() !void {
     var fbs = std.io.fixedBufferStream(data);
     const reader = fbs.reader();
 
-    if (no_fs) {
-        // Run tar parser
-        var tar = std.tar.iterator(reader, null);
-        while (tar.next() catch null) |file| {
-            switch (file.kind) {
-                .directory => {},
-                .normal => {
-                    file.write(std.io.null_writer) catch |err| {
-                        if (err == error.EndOfStream) break;
-                        return err;
-                    };
-                },
-                .symbolic_link => {},
-                else => unreachable,
-            }
+    // Run tar parser
+    var tar = std.tar.iterator(reader, null);
+    while (tar.next() catch null) |file| {
+        switch (file.kind) {
+            .directory => {},
+            .normal => {
+                file.write(std.io.null_writer) catch |err| {
+                    if (err == error.EndOfStream) break;
+                    return err;
+                };
+            },
+            .symbolic_link => {},
+            else => unreachable,
         }
-    } else {
-        // Run tar parser and write untar data to the file system
-        const rand_int = std.crypto.random.int(u64);
-        tmp_dirpath = std.fmt.bufPrint(&tmp_buf, "/tmp/zig-tar-fuzzing/{x}", .{rand_int}) catch unreachable;
-
-        const tmpdir = try std.fs.cwd().makeOpenPath(tmp_dirpath.?, .{});
-        defer std.fs.cwd().deleteTree(tmp_dirpath.?) catch |err| {
-            std.debug.print("failed to deleteTree during defer: {}\n", .{err});
-            @panic("failed to deleteTree in defer");
-        };
-        std.tar.pipeToFileSystem(tmpdir, reader, .{ .mode_mode = .ignore }) catch {};
     }
 }


### PR DESCRIPTION
I updated tar fuzzer to work with current Zig. 
In the fuzzer I add option to run just parser without writing untar files to the file system. That enables little faster fuzzing. 

I'm running this and reached an assert in the std.tar, will fix that and make PR to the Zig repo. 